### PR TITLE
Delete a quotation marks for the shellescaped path

### DIFF
--- a/lib/fastlane/plugin/instabug_official/actions/instabug_official_action.rb
+++ b/lib/fastlane/plugin/instabug_official/actions/instabug_official_action.rb
@@ -16,7 +16,7 @@ module Fastlane
         
         endpoint = 'https://api.instabug.com/api/ios/v1/dsym'
         
-        command =  "curl #{endpoint} --write-out %{http_code} --silent --output /dev/null -F dsym=@\"#{dsym_zip_path}\" -F token=\"#{api_token}\""
+        command =  "curl #{endpoint} --write-out %{http_code} --silent --output /dev/null -F dsym=@#{dsym_zip_path} -F token=\"#{api_token}\""
         
         UI.verbose command
         


### PR DESCRIPTION
Shellescaped string should be used unquoted.

>Note that a resulted string should be used unquoted and is not intended for use in double quotes nor in single quotes.

http://ruby-doc.org/stdlib-2.0.0/libdoc/shellwords/rdoc/Shellwords.html#method-c-shellescape